### PR TITLE
Replace None id class

### DIFF
--- a/geodataset/dataset/raster_dataset.py
+++ b/geodataset/dataset/raster_dataset.py
@@ -79,7 +79,7 @@ class LabeledRasterCocoDataset(BaseDataset, ABC):
         self.cocos_detected.append(json_path)
 
     def _reindex_coco_data(self, coco_data: dict):
-        """s
+        """
         Re-indexes the COCO data to ensure unique tile and annotation IDs.
 
         Parameters:


### PR DESCRIPTION
Replace None id class with 0 => default class for "trees but we don't know which"
+ fix on removing tiles without labels for all splits (not useful for any train/val/test if no annotation)