### PR TITLE
update: unlabelled rasters and reforestree categories

### DIFF
--- a/geodataset/dataset/raster_dataset.py
+++ b/geodataset/dataset/raster_dataset.py
@@ -274,9 +274,13 @@ class UnlabeledRasterDataset(BaseDataset):
 
         for directory in directories:
             if directory.is_dir() and directory.name == 'tiles':
-                for path in directory.iterdir():
-                    if path.suffix == ".tif":
-                        self.tile_paths.append(path)
+                fold_directory = (directory / self.fold)
+                # Datasets may not contain all splits
+                if fold_directory.exists():
+                    for path in fold_directory.iterdir():
+                        # Iterate within the corresponding split folder
+                        if path.suffix == ".tif":
+                            self.tile_paths.append(path)
 
             if directory.is_dir():
                 for path in directory.iterdir():

--- a/geodataset/tilerize/raster_tilerizer.py
+++ b/geodataset/tilerize/raster_tilerizer.py
@@ -290,7 +290,9 @@ class RasterTilerizer(BaseDiskRasterTilerizer):
 
             # Save the tile images
             for tile in aois_tiles[aoi]:
-                tile.save(output_folder=self.tiles_path)
+                tiles_path_aoi = self.tiles_path / aoi
+                tiles_path_aoi.mkdir(parents=True, exist_ok=True)
+                tile.save(output_folder=tiles_path_aoi)
 
         print(f"The tiles have been saved to {self.tiles_path}.")
 

--- a/geodataset/utils/categories/reforestree/reforestree_categories.json
+++ b/geodataset/utils/categories/reforestree/reforestree_categories.json
@@ -1,0 +1,52 @@
+{
+  "categories": [
+    {
+      "id": 1,
+      "name": "other",
+      "global_id": 1,
+      "rank": null,
+      "other_names": [],
+      "supercategory": null
+    },
+    {
+      "id": 2,
+      "name": "banana",
+      "global_id": 2,
+      "rank": null,
+      "other_names": [],
+      "supercategory": null
+    },
+    {
+      "id": 3,
+      "name": "cacao",
+      "global_id": 3,
+      "rank": null,
+      "other_names": [],
+      "supercategory": null
+    },
+    {
+      "id": 4,
+      "name": "citrus",
+      "global_id": 4,
+      "rank": null,
+      "other_names": [],
+      "supercategory": null
+    },
+    {
+      "id": 5,
+      "name": "timber",
+      "global_id": 5,
+      "rank": null,
+      "other_names": [],
+      "supercategory": null
+    },
+    {
+      "id": 6,
+      "name": "fruit",
+      "global_id": 6,
+      "rank": null,
+      "other_names": [],
+      "supercategory": null
+    }
+  ]
+}


### PR DESCRIPTION
Description of the modifications:

- [geodataset/tilerize/raster_tilerizer.py](https://github.com/hugobaudchon/geodataset/compare/arthur?expand=1#diff-8cabe9c3ad032b5e49bef62b90132d01611a8adc42aa9659b0b4edc5709f012d): create a folder per "fold" (= split) for unlabelled raster tilerizer.
- [geodataset/dataset/raster_dataset.py](https://github.com/hugobaudchon/geodataset/compare/arthur?expand=1#diff-e5cfdc4c0789b9689cd561d27ff4597a9dfa46f79c903e3426f18c40f9960d3b): consider the split folders within the dataloader for unlabelled rasters.
- [geodataset/utils/categories/reforestree/reforestree_categories.json](https://github.com/hugobaudchon/geodataset/compare/arthur?expand=1#diff-02c1e7181ab3d3828e0cc48095e26287d91dca801c4e6a6bf9700d4bc389a858): add categories for the ReforesTree dataset.

Hope this will help :) 