### PR TITLE
Removed base64 encoding for RLE segmentations

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -106,7 +106,6 @@ The class LabeledRasterTilerizer can tilerize a raster and its labels (.gpkg, .g
         aois_config=aoi_gpkg_config,
         ground_resolution=0.05,                          # optional, scale_factor must be None if used.
         scale_factor=0.5,                                # optional, ground_resolution must be None if used.
-        use_rle_for_labels=True,                         # optional
         min_intersection_ratio=0.9,                      # optional
         ignore_tiles_without_labels=False,               # optional
         ignore_black_white_alpha_tiles_threshold=0.8,    # optional

--- a/geodataset/aggregator/aggregator.py
+++ b/geodataset/aggregator/aggregator.py
@@ -762,7 +762,6 @@ class Aggregator:
                 categories=None,  # TODO add support for categories
                 other_attributes=other_attributes,
                 output_path=self.output_path,
-                use_rle_for_labels=True,  # TODO make this a parameter to the class
                 n_workers=5,  # TODO make this a parameter to the class
                 coco_categories_list=None  # TODO make this a parameter to the class
             )

--- a/geodataset/dataset/raster_dataset.py
+++ b/geodataset/dataset/raster_dataset.py
@@ -83,14 +83,7 @@ class DetectionLabeledRasterCocoDataset(BaseLabeledRasterCocoDataset):
                 bbox = box(*[bbox_coco[0], bbox_coco[1], bbox_coco[0] + bbox_coco[2], bbox_coco[1] + bbox_coco[3]])
             else:
                 segmentation = label['segmentation']
-                if ('is_rle_format' in label and label['is_rle_format']) or isinstance(segmentation, dict):
-                    # RLE format
-                    bbox = coco_rle_segmentation_to_bbox(segmentation)
-                elif ('is_rle_format' in label and not label['is_rle_format']) or isinstance(segmentation, list):
-                    # Polygon (coordinates) format
-                    bbox = coco_coordinates_segmentation_to_bbox(segmentation)
-                else:
-                    raise NotImplementedError("Could not find the segmentation type (RLE vs polygon coordinates).")
+                bbox = coco_rle_segmentation_to_bbox(segmentation)
 
             if self.box_padding_percentage:
                 minx, miny, maxx, maxy = bbox.bounds
@@ -200,12 +193,8 @@ class SegmentationLabeledRasterCocoDataset(BaseLabeledRasterCocoDataset):
 
         for label in labels:
             if 'segmentation' in label:
-                segmentation = label['segmentation']
-                if ('is_rle_format' in label and label['is_rle_format']) or isinstance(segmentation, dict):
-                    # RLE format
-                    mask = coco_rle_segmentation_to_mask(segmentation)
-                else:
-                    raise NotImplementedError("Please make sure that the masks are encoded using RLE.")
+                rle_segmentation = label['segmentation']
+                mask = coco_rle_segmentation_to_mask(rle_segmentation)
 
                 masks.append(mask)
 
@@ -304,16 +293,9 @@ class InstanceSegmentationLabeledRasterCocoDataset(BaseLabeledRasterCocoDataset)
         bboxes = []
 
         for label in labels:
-            segmentation = label['segmentation']
-            if ('is_rle_format' in label and label['is_rle_format']) or isinstance(segmentation, dict):
-                # RLE format
-                bbox = coco_rle_segmentation_to_bbox(segmentation)
-                mask = coco_rle_segmentation_to_mask(segmentation)
-            elif ('is_rle_format' in label and not label['is_rle_format']) or isinstance(segmentation, list):
-                bbox = coco_coordinates_segmentation_to_bbox(segmentation)
-                mask = polygon_to_mask(segmentation, tile_info['height'], tile_info['width'])
-            else:
-                raise NotImplementedError("Please make sure that the masks are encoded using RLE.")
+            rle_segmentation = label['segmentation']
+            bbox = coco_rle_segmentation_to_bbox(rle_segmentation)
+            mask = coco_rle_segmentation_to_mask(rle_segmentation)
 
             if self.box_padding_percentage:
                 minx, miny, maxx, maxy = bbox.bounds

--- a/geodataset/tilerize/labeled_point_cloud_tilerizer.py
+++ b/geodataset/tilerize/labeled_point_cloud_tilerizer.py
@@ -46,8 +46,6 @@ class LabeledPointCloudTilerizer(PointCloudTilerizer):
         Name of the main label category column, by default None.
     other_labels_attributes_column_names : List[str], optional
         List of other label attributes, by default None.
-    use_rle_for_labels : bool, optional
-        Whether to use RLE for labels, by default True.
     coco_n_workers : int, optional
         Number of workers for the COCO dataset, by default 1.
     tile_side_length : float, optional
@@ -80,7 +78,6 @@ class LabeledPointCloudTilerizer(PointCloudTilerizer):
         geopackage_layer_name: str = None,
         main_label_category_column_name: str = "Label",
         other_labels_attributes_column_names: List[str] = None,
-        use_rle_for_labels: bool = True,
         coco_n_workers: int = 1,
         tile_overlap: float = 0.5,
         max_tile: int = 50000,
@@ -100,7 +97,6 @@ class LabeledPointCloudTilerizer(PointCloudTilerizer):
         self.main_label_category_column_name = main_label_category_column_name
         self.other_labels_attributes_column_names = other_labels_attributes_column_names
         self.aois_config = aois_config
-        self.use_rle_for_labels = use_rle_for_labels
         self.coco_n_workers = coco_n_workers
         self.coco_categories_list = coco_categories_list
         self.downsample_voxel_size = downsample_voxel_size
@@ -141,17 +137,13 @@ class LabeledPointCloudTilerizer(PointCloudTilerizer):
 
             self.populate_tiles_metadata()
 
-        if self.use_rle_for_labels:
-            assert self.tiles_metadata is not None, "Tile metadata is required for RLE encoding (image height and width)"
-            assert self.tiles_metadata.height is not None and self.tiles_metadata.width is not None, "Height and width of the tiles are required for RLE encoding"
+        assert self.tiles_metadata is not None, "Tile metadata is required for RLE encoding (image height and width)"
+        assert self.tiles_metadata.height is not None and self.tiles_metadata.width is not None, "Height and width of the tiles are required for RLE encoding"
 
         assert (
             len(self.tiles_metadata) < max_tile
         ), f"Number of max possible tiles {len(self.tiles_metadata)} exceeds the maximum number of tiles {max_tile}"
 
-        # if self.use_rle_for_labels:
-        #     assert self.til #??
-        # Processing AOIs
         if self.aois_config is None:
             raise Exception("Please provide an aoi_config. Currently don't support 'None'.")
         self.aoi_engine = AOIBaseFromGeoFileInCRS(aois_config)
@@ -466,7 +458,6 @@ class LabeledPointCloudTilerizer(PointCloudTilerizer):
                 categories=categories_list,
                 other_attributes=other_attributes_dict_list,
                 output_path=coco_output_file_path,
-                use_rle_for_labels=self.use_rle_for_labels,
                 n_workers=self.coco_n_workers,
                 coco_categories_list=self.coco_categories_list,
             )

--- a/geodataset/tilerize/labeled_raster_tilerizer.py
+++ b/geodataset/tilerize/labeled_raster_tilerizer.py
@@ -44,8 +44,6 @@ class LabeledRasterTilerizer(BaseDiskRasterTilerizer):
         Suffix to add to the output file names.
     ignore_black_white_alpha_tiles_threshold : float, optional
         Threshold ratio of black, white or transparent pixels in a tile to skip it. Default is 0.8.
-    use_rle_for_labels : bool, optional
-        Whether to use RLE encoding for the labels. If False, the labels will be saved as polygons.
     min_intersection_ratio : float, optional
         When finding the associated polygon labels to a tile, this ratio will specify the minimal required intersection
         ratio (intersecting_polygon_area / polygon_area) between a candidate polygon and the tile in order to keep this
@@ -62,7 +60,6 @@ class LabeledRasterTilerizer(BaseDiskRasterTilerizer):
         as a dictionary in the COCO annotations data.
     coco_n_workers : int, optional
         Number of workers to use when generating the COCO dataset.
-        Useful when use_rle_for_labels=True as it is quite slow.
     coco_categories_list : list of dict, optional
         A list of category dictionaries in COCO format. If a polygon has a category (label in
         'main_label_category_column_name') that is not in this list, its category_id will be set to None in its COCO
@@ -114,7 +111,6 @@ class LabeledRasterTilerizer(BaseDiskRasterTilerizer):
                  scale_factor: float = None,
                  output_name_suffix: str = None,
                  ignore_black_white_alpha_tiles_threshold: float = 0.8,
-                 use_rle_for_labels: bool = True,
                  min_intersection_ratio: float = 0.9,
                  ignore_tiles_without_labels: bool = False,
                  geopackage_layer_name: str = None,
@@ -134,7 +130,6 @@ class LabeledRasterTilerizer(BaseDiskRasterTilerizer):
                          ignore_black_white_alpha_tiles_threshold=ignore_black_white_alpha_tiles_threshold)
 
         self.labels_path = Path(labels_path)
-        self.use_rle_for_labels = use_rle_for_labels
         self.min_intersection_ratio = min_intersection_ratio
         self.ignore_tiles_without_labels = ignore_tiles_without_labels
         self.coco_n_workers = coco_n_workers
@@ -318,7 +313,6 @@ class LabeledRasterTilerizer(BaseDiskRasterTilerizer):
                 categories=categories_list,
                 other_attributes=other_attributes_dict_list,
                 output_path=coco_output_file_path,
-                use_rle_for_labels=self.use_rle_for_labels,
                 n_workers=self.coco_n_workers,
                 coco_categories_list=self.coco_categories_list
             )

--- a/geodataset/tilerize/raster_polygon_tilerizer.py
+++ b/geodataset/tilerize/raster_polygon_tilerizer.py
@@ -26,7 +26,6 @@ class RasterPolygonTilerizer:
                  ground_resolution: float or None,
                  scale_factor: float or None,
                  output_name_suffix: str = None,
-                 use_rle_for_labels: bool = True,
                  min_intersection_ratio: float = 0.5,
                  geopackage_layer_name: str = None,
                  main_label_category_column_name: str = None,
@@ -42,7 +41,6 @@ class RasterPolygonTilerizer:
         self.variable_tile_size_pixel_buffer = variable_tile_size_pixel_buffer
         self.aois_config = aois_config
         self.output_name_suffix = output_name_suffix
-        self.use_rle_for_labels = use_rle_for_labels
         self.min_intersection_ratio = min_intersection_ratio
         self.coco_n_workers = coco_n_workers
         self.coco_categories_list = coco_categories_list
@@ -230,7 +228,6 @@ class RasterPolygonTilerizer:
                 categories=categories_list,
                 other_attributes=other_attributes_dict_list,
                 output_path=coco_output_file_path,
-                use_rle_for_labels=self.use_rle_for_labels,
                 n_workers=self.coco_n_workers,
                 coco_categories_list=self.coco_categories_list
             )


### PR DESCRIPTION
Removed base64 encoding for RLE segmentations when creating COCO datasets as it's not standard practice. COCO files generated are now compatible with pycocotools.