### PR TITLE
Usage of BigTIFF for files > 4GB in utils

### DIFF
--- a/geodataset/utils/utils.py
+++ b/geodataset/utils/utils.py
@@ -666,6 +666,8 @@ def read_raster(path: Path, ground_resolution: float = None, scale_factor: float
                 resampling=Resampling.bilinear
             )
         memfile = MemoryFile()
+        if expected_bytes > 4 * 1024 ** 3:
+            profile.update({"BIGTIFF": "YES"})
         with memfile.open(**profile) as mem_ds:
             mem_ds.write(data)
         dataset = memfile.open()


### PR DESCRIPTION
This pull request introduces an update to the raster reading utility in `geodataset/utils/utils.py` to fix handling of raster files larger than 4GB and smaller than 10GB. The main change ensures that if the raster file size exceeds 4GB, the output profile is updated to enable BigTIFF support, which allows for writing larger TIFF files. [(https://gdal.org/en/stable/drivers/raster/gtiff.html)](https://gdal.org/en/stable/drivers/raster/gtiff.html)

Raster file handling improvement:

* In the `read_raster` function, added logic to update the output `profile` with `"BIGTIFF": "YES"` when the expected file size is greater than 4GB, ensuring compatibility with large raster datasets.