### PR TITLE
hugo-dev: COCO mask decoding fix + RasterPolygonTilerizer improvements + Quebec tree categories

### DIFF
--- a/geodataset/aggregator/aggregator.py
+++ b/geodataset/aggregator/aggregator.py
@@ -564,15 +564,20 @@ class Aggregator:
         with open(coco_json_path, 'r') as f:
             coco_data = json.load(f)
 
+        # Image (tile) sizes, keyed by image id (COCO stores size on the image, not the annotation)
+        image_id_to_size = {img['id']: (img['height'], img['width']) for img in coco_data['images']}
+
         # Reading the polygons
         tile_ids_to_polygons = {}
         tile_ids_to_attributes = {}
         for annotation in coco_data['annotations']:
             image_id = annotation['image_id']
+            image_height, image_width = image_id_to_size[image_id]
 
             annotation_polygon = decode_coco_segmentation(
                 annotation,
-                polygon_type if polygon_type == 'bbox' else 'polygon'   # 'polygon' for segmentation
+                polygon_type if polygon_type == 'bbox' else 'polygon',   # 'polygon' for segmentation
+                image_height, image_width
             )
 
             attributes = {}

--- a/geodataset/dataset/raster_dataset.py
+++ b/geodataset/dataset/raster_dataset.py
@@ -77,7 +77,7 @@ class DetectionLabeledRasterCocoDataset(BaseLabeledRasterCocoDataset):
         bboxes = []
 
         for label in labels:
-            bbox = decode_coco_segmentation(label, 'bbox')
+            bbox = decode_coco_segmentation(label, 'bbox', tile_info['height'], tile_info['width'])
 
             if self.box_padding_percentage:
                 minx, miny, maxx, maxy = bbox.bounds
@@ -195,7 +195,7 @@ class SegmentationLabeledRasterCocoDataset(BaseLabeledRasterCocoDataset):
 
         for label in labels:
             if 'segmentation' in label:
-                mask = decode_coco_segmentation(label, 'mask')
+                mask = decode_coco_segmentation(label, 'mask', tile_info['height'], tile_info['width'])
                 masks.append(mask)
 
         if self.force_binary_class:
@@ -302,8 +302,8 @@ class InstanceSegmentationLabeledRasterCocoDataset(BaseLabeledRasterCocoDataset)
         bboxes = []
 
         for label in labels:
-            bbox = decode_coco_segmentation(label, 'bbox')
-            mask = decode_coco_segmentation(label, 'mask')
+            bbox = decode_coco_segmentation(label, 'bbox', tile_info['height'], tile_info['width'])
+            mask = decode_coco_segmentation(label, 'mask', tile_info['height'], tile_info['width'])
 
             if self.box_padding_percentage:
                 minx, miny, maxx, maxy = bbox.bounds

--- a/geodataset/geodata/raster.py
+++ b/geodataset/geodata/raster.py
@@ -6,7 +6,6 @@ from math import floor
 from pathlib import Path
 from typing import Tuple, List
 
-import cv2
 import numpy as np
 import rasterio
 from rasterio.windows import Window
@@ -186,7 +185,6 @@ class Raster:
         col_off = int(floor(cx - final_tile_size / 2))
         row_off = int(floor(cy - final_tile_size / 2))
         window = Window(col_off=col_off, row_off=row_off, width=final_tile_size, height=final_tile_size)
-        binary_mask = np.zeros((final_tile_size, final_tile_size), dtype=np.uint8)
 
         window_transform = rasterio.windows.transform(window, self.metadata['transform'])
         tile_metadata = {
@@ -211,24 +209,10 @@ class Raster:
         # Translate the polygon into the tile frame of reference
         translated_inter = translate(inter, xoff=-col_off, yoff=-row_off)
 
-        # Ensure the result has an exterior before accessing its coordinates
-        if not translated_inter.is_empty:
-            contours = np.array(translated_inter.exterior.coords).reshape((-1, 1, 2)).astype(np.int32)
-        else:
-            # Handle the case when the intersection is empty (e.g., set contours to an empty array)
-            contours = np.array([])
-
-        # Check if contours is not empty before calling cv2.fillPoly
-        if contours.size > 0:
-            cv2.fillPoly(binary_mask, [contours], 1)
-        else:
-            # Handle the case where there are no contours (e.g., skip filling the polygon)
-            pass
-
         # Creating the RasterTileMetadata, with the appropriate metadata
         polygon_tile = RasterTileMetadata(
             associated_raster=self,
-            mask=binary_mask,
+            mask=None,
             metadata=tile_metadata,
             ground_resolution=self.ground_resolution,
             scale_factor=self.scale_factor,

--- a/geodataset/geodata/raster.py
+++ b/geodataset/geodata/raster.py
@@ -469,7 +469,8 @@ class RasterTileMetadata:
     def save(self,
              output_folder: str or Path,
              apply_mask: bool = True,
-             output_dtype: str = None):
+             output_dtype: str = None,
+             compress: str = None):
         """
         Save the tile as a .tif file in the output_folder.
 
@@ -539,13 +540,19 @@ class RasterTileMetadata:
             else:
                 raise NotImplementedError(f"The output dtype {output_dtype} is not supported yet.")
 
+        if compress == 'zstd':
+            try:
+                is_float = np.issubdtype(np.dtype(self.metadata['dtype']), np.floating)
+            except (TypeError, AttributeError):
+                is_float = False
+            compress_kwargs = {'compress': 'zstd', 'predictor': 3 if is_float else 2}
+        else:
+            compress_kwargs = {}
         with rasterio.open(
                 output_folder / tile_name,
                 'w',
                 **self.metadata,
-                # compress='zstd',  # Lossless compression
-                # predictor=2,  # For integer data; use predictor=3 for floating point if needed
-                # tiled=True  # Enables tiling, which can improve compression efficiency
+                **compress_kwargs,
         ) as tile_raster:
 
             tile_raster.write(data)
@@ -638,7 +645,8 @@ class RasterTileSaver:
                   tile: RasterTileMetadata,
                   output_folder: Path,
                   apply_mask: bool = True,
-                  output_dtype: str = None):
+                  output_dtype: str = None,
+                  compress: str = None):
         """
         Save a single tile.
 
@@ -653,9 +661,11 @@ class RasterTileSaver:
         output_dtype: str
             The data type to use when saving the tile. If None, the original data type will
             be used. Currently supported values are None and  'uint8' (0-255).
+        compress: str
+            Compression to apply when saving the tile. Supported values are None and 'zstd'.
         """
         try:
-            tile.save(output_folder=output_folder, apply_mask=apply_mask, output_dtype=output_dtype)
+            tile.save(output_folder=output_folder, apply_mask=apply_mask, output_dtype=output_dtype, compress=compress)
         except Exception as e:
             print(f"Error saving tile {tile.generate_name()}: {str(e)}")
 
@@ -663,7 +673,8 @@ class RasterTileSaver:
                        tiles: List[RasterTileMetadata],
                        output_folder: Path,
                        apply_mask: bool = True,
-                       output_dtype: str = None):
+                       output_dtype: str = None,
+                       compress: str = None):
         """
         Save all the tiles in parallel using ThreadPoolExecutor.
 
@@ -678,11 +689,13 @@ class RasterTileSaver:
         output_dtype: str
             The data type to use when saving the tile. If None, the original data type will
             be used. Currently supported values are None and  'uint8' (0-255).
+        compress: str
+            Compression to apply when saving the tile. Supported values are None and 'zstd'.
         """
         # Use ThreadPoolExecutor to manage threads
         with ThreadPoolExecutor(max_workers=self.n_workers) as executor:
             # Submit tasks to the executor
-            futures = [executor.submit(self.save_tile, tile, output_folder, apply_mask, output_dtype) for tile in tiles]
+            futures = [executor.submit(self.save_tile, tile, output_folder, apply_mask, output_dtype, compress) for tile in tiles]
 
             for future in concurrent.futures.as_completed(futures):
                 try:

--- a/geodataset/geodata/raster.py
+++ b/geodataset/geodata/raster.py
@@ -176,7 +176,8 @@ class Raster:
             # Variable tile size centered on the polygon centroid, with a minimum size of tile_size and that doesn't go outside the raster bounds
             max_dist_to_polygon_border = max(
                 [x - polygon.bounds[0], polygon.bounds[2] - cx, cy - polygon.bounds[1], polygon.bounds[3] - cy])
-            final_tile_size = int(min(tile_size, max_dist_to_polygon_border * 2 + variable_tile_size_pixel_buffer * 2))
+            uncapped_size = max_dist_to_polygon_border * 2 + variable_tile_size_pixel_buffer * 2
+            final_tile_size = int(uncapped_size if tile_size is None else min(tile_size, uncapped_size))
         else:
             # Fixed tile size centered on the polygon centroid
             final_tile_size = tile_size
@@ -506,10 +507,33 @@ class RasterTileMetadata:
                         else:
                             # Float data in 0.0-1.0 range - use standard conversion
                             data = img_as_ubyte(data)
+                    elif data.dtype == np.uint16:
+                        # For uint16, use standard conversion (scikit-image handles it correctly)
+                        data = img_as_ubyte(data)
+                    elif data.dtype in [np.int32, np.int64, np.uint32]:
+                        # For int32/int64/uint32, img_as_ubyte normalizes based on dtype range
+                        # which is incorrect if actual values are in a smaller range (e.g., 0-65535)
+                        # Treat as uint16 data (0-65535) and scale to 0-255 for consistency across tiles
+                        nodata_val = self.metadata.get('nodata', None)
+                        if nodata_val is not None:
+                            valid_mask = data != nodata_val
+                        else:
+                            valid_mask = np.ones(data.shape, dtype=bool)
+
+                        # Normalize from 0-65535 to 0-255 (treating as uint16 data)
+                        data = np.clip(data, 0, 65535)
+                        data = (data.astype(np.float64) / 65535 * 255).astype(np.uint8)
+
+                        # Set nodata pixels to 0
+                        if nodata_val is not None:
+                            data[~valid_mask] = 0
                     else:
-                        # For integer types (uint16, etc.), use standard conversion
+                        # For other integer types (uint8, int8, int16, etc.), use standard conversion
                         data = img_as_ubyte(data)
                     self.metadata['dtype'] = 'uint8'
+                    # Update nodata to be compatible with uint8 (or remove it)
+                    if self.metadata.get('nodata') is not None:
+                        self.metadata['nodata'] = 0
                 # else: already uint8, no conversion needed
             else:
                 raise NotImplementedError(f"The output dtype {output_dtype} is not supported yet.")

--- a/geodataset/geodata/raster.py
+++ b/geodataset/geodata/raster.py
@@ -132,7 +132,8 @@ class Raster:
                          polygon_aoi: str,
                          tile_size: int,
                          use_variable_tile_size: bool,
-                         variable_tile_size_pixel_buffer: int) -> Tuple["RasterPolygonTileMetadata", Polygon]:
+                         variable_tile_size_pixel_buffer: int,
+                         min_tile_size: int = None) -> Tuple["RasterPolygonTileMetadata", Polygon]:
 
         """
         Generates and returns a RasterTileMetadata from a Polygon geometry, along with the possibly cropped original Polygon.
@@ -169,15 +170,15 @@ class Raster:
         # find largest polygon and center tile around it
         polygon = fix_geometry_collection(polygon)
         polygon = try_cast_multipolygon_to_polygon(polygon, strategy='largest_part')
-        x, y = polygon.centroid.coords[0]
         cx, cy = polygon.centroid.coords[0]
 
         if use_variable_tile_size:
             # Variable tile size centered on the polygon centroid, with a minimum size of tile_size and that doesn't go outside the raster bounds
             max_dist_to_polygon_border = max(
-                [x - polygon.bounds[0], polygon.bounds[2] - cx, cy - polygon.bounds[1], polygon.bounds[3] - cy])
+                [cx - polygon.bounds[0], polygon.bounds[2] - cx, cy - polygon.bounds[1], polygon.bounds[3] - cy])
             uncapped_size = max_dist_to_polygon_border * 2 + variable_tile_size_pixel_buffer * 2
-            final_tile_size = int(uncapped_size if tile_size is None else min(tile_size, uncapped_size))
+            capped_size = uncapped_size if tile_size is None else min(tile_size, uncapped_size)
+            final_tile_size = int(max(min_tile_size, capped_size) if min_tile_size is not None else capped_size)
         else:
             # Fixed tile size centered on the polygon centroid
             final_tile_size = tile_size

--- a/geodataset/tilerize/raster_polygon_tilerizer.py
+++ b/geodataset/tilerize/raster_polygon_tilerizer.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from typing import List, cast, Optional
 
@@ -8,6 +9,7 @@ from tqdm import tqdm
 
 from geodataset.aoi import AOIFromPackageConfig, AOIGeneratorConfig, AOIConfig
 from geodataset.aoi.aoi_base import DEFAULT_AOI_NAME
+from geodataset.aoi.aoi_disambiguator import AOIDisambiguator
 from geodataset.aoi.aoi_from_package import AOIFromPackageForPolygons
 from geodataset.geodata import Raster, RasterTileMetadata
 from geodataset.geodata.raster import RasterTileSaver
@@ -141,6 +143,11 @@ class RasterPolygonTilerizer:
     compress : str, optional
         Compression to apply when saving tiles. Supported values are None (no compression)
         and 'zstd' (lossless). Defaults to None.
+    apply_aoi_mask : bool, optional
+        Whether to zero out pixels outside the AOI boundary when saving tiles. Only has an
+        effect when aois_config is an AOIFromPackageConfig. It is strongly recommended to
+        enable this to avoid spatial autocorrelation between tiles from different AOIs
+        (e.g. train/valid leakage). Defaults to False.
     """
 
     unique_polygon_id_column_name = 'polygon_id_geodataset'
@@ -169,7 +176,8 @@ class RasterPolygonTilerizer:
                  tile_batch_size: int = 1000,
                  temp_dir: str or Path = './tmp',
                  output_dtype: str = None,
-                 compress: str = None):
+                 compress: str = None,
+                 apply_aoi_mask: bool = False):
 
         self.raster_path = str(raster_path)
         self.labels_path = Path(labels_path) if labels_path is not None else None
@@ -190,6 +198,7 @@ class RasterPolygonTilerizer:
         self.temp_dir = Path(temp_dir)
         self.output_dtype = output_dtype
         self.compress = compress
+        self.apply_aoi_mask = apply_aoi_mask
 
         self._check_parameters()
         self._check_aois_config()
@@ -235,6 +244,12 @@ class RasterPolygonTilerizer:
             self.aois_config = AOIGeneratorConfig(aois={DEFAULT_AOI_NAME: {'percentage': 1.0, 'position': 1}}, aoi_type='band')
         else:
             self.aois_config = self.aois_config
+
+        if isinstance(self.aois_config, AOIFromPackageConfig) and not self.apply_aoi_mask:
+            warnings.warn("RasterPolygonTilerizer: apply_aoi_mask is False. Pixels outside the AOI boundary will not be "
+                          "zeroed out when saving tiles. It is strongly recommended to enable this to avoid spatial "
+                          "autocorrelation between tiles from different AOIs (e.g. train/valid leakage).",
+                          UserWarning, stacklevel=2)
 
     def _load_raster(self):
         raster = Raster(path=self.raster_path,
@@ -391,16 +406,35 @@ class RasterPolygonTilerizer:
                 final_aois_polygons[aoi].append(gdf)
 
                 if len(tiles_batch) == self.tile_batch_size:
+                    self._apply_aoi_masks_to_batch(tiles_batch, aoi, aois_gdf)
                     tiles_paths = self._save_tiles_batch(tiles_batch, aoi=aoi)
                     tiles_batch = []
                     final_aois_tiles_paths[aoi].extend(tiles_paths)
 
             if len(tiles_batch) > 0:
+                self._apply_aoi_masks_to_batch(tiles_batch, aoi, aois_gdf)
                 tiles_paths = self._save_tiles_batch(tiles_batch, aoi=aoi)
                 tiles_batch = []
                 final_aois_tiles_paths[aoi].extend(tiles_paths)
 
         return final_aois_tiles_paths, final_aois_polygons
+
+    def _apply_aoi_masks_to_batch(self, tiles: List[RasterTileMetadata], aoi: str, aois_gdf: gpd.GeoDataFrame):
+        if not isinstance(self.aois_config, AOIFromPackageConfig):
+            return
+        tiles_gdf = gpd.GeoDataFrame(
+            [{
+                'geometry': t.get_bbox(),
+                'tile_id': t.tile_id,
+                'aoi': t.aoi
+            } for t in tiles],
+            crs=None
+        )
+        AOIDisambiguator(
+            tiles_gdf=tiles_gdf,
+            aois_tiles={aoi: tiles},
+            aois_gdf=aois_gdf
+        ).disambiguate_tiles()
 
     def _save_tiles_batch(self, tiles: List[RasterTileMetadata], aoi: str):
         (self.tiles_folder_path / aoi).mkdir(parents=True, exist_ok=True)
@@ -409,7 +443,7 @@ class RasterPolygonTilerizer:
         tile_saver.save_all_tiles(
             tiles,
             output_folder=self.tiles_folder_path / aoi,
-            apply_mask=False,  # We don't apply mask for polygon tiles and let user handle it if needed when loading it for training/inference
+            apply_mask=self.apply_aoi_mask,
             output_dtype=self.output_dtype,
             compress=self.compress
         )

--- a/geodataset/tilerize/raster_polygon_tilerizer.py
+++ b/geodataset/tilerize/raster_polygon_tilerizer.py
@@ -37,6 +37,9 @@ class RasterPolygonTilerizer:
          with a buffer defined by variable_tile_size_pixel_buffer.
     variable_tile_size_pixel_buffer: int or None
         If use_variable_tile_size is True, this parameter defines the pixel buffer to add around the polygon when creating the tile.
+    min_tile_size : int or None, optional
+        Only used when use_variable_tile_size is True. Defines the minimum tile size in pixels.
+        If None, no minimum is enforced. Defaults to None.
     labels_gdf: geopandas.GeoDataFrame, optional
         A GeoDataFrame containing the labels. If provided, labels_path must be None.
     global_aoi : str or pathlib.Path or geopandas.GeoDataFrame, optional
@@ -146,6 +149,7 @@ class RasterPolygonTilerizer:
                  tile_size: Optional[int],
                  use_variable_tile_size: bool,
                  variable_tile_size_pixel_buffer: int or None,
+                 min_tile_size: Optional[int] = None,
                  labels_gdf: gpd.GeoDataFrame = None,
                  global_aoi: str or Path or gpd.GeoDataFrame = None,
                  aois_config: Optional[AOIConfig] = None,
@@ -168,6 +172,7 @@ class RasterPolygonTilerizer:
         self.tile_size = tile_size
         self.use_variable_tile_size = use_variable_tile_size
         self.variable_tile_size_pixel_buffer = variable_tile_size_pixel_buffer
+        self.min_tile_size = min_tile_size
         self.global_aoi = global_aoi
         self.aois_config = aois_config
         self.scale_factor = scale_factor
@@ -204,6 +209,8 @@ class RasterPolygonTilerizer:
         if self.use_variable_tile_size:
             assert self.tile_size is None or (isinstance(self.tile_size, int) and self.tile_size > 0), \
                 "tile_size must be a positive integer or None when use_variable_tile_size is True."
+            assert self.min_tile_size is None or (isinstance(self.min_tile_size, int) and self.min_tile_size > 0), \
+                "min_tile_size must be a positive integer or None."
         else:
             assert isinstance(self.tile_size, int) and self.tile_size > 0, \
                 "tile_size must be a positive integer when use_variable_tile_size is False."
@@ -338,7 +345,8 @@ class RasterPolygonTilerizer:
                     polygon_aoi=aoi,
                     tile_size=self.tile_size,
                     use_variable_tile_size=self.use_variable_tile_size,
-                    variable_tile_size_pixel_buffer=self.variable_tile_size_pixel_buffer
+                    variable_tile_size_pixel_buffer=self.variable_tile_size_pixel_buffer,
+                    min_tile_size=self.min_tile_size
                 )
 
                 tiles_batch.append(polygon_tile)

--- a/geodataset/tilerize/raster_polygon_tilerizer.py
+++ b/geodataset/tilerize/raster_polygon_tilerizer.py
@@ -325,19 +325,31 @@ class RasterPolygonTilerizer:
         return aois_polygons, aois_gdf
 
     def _generate_aois_tiles_and_polygons(self):
-        aois_polygons, _ = self._generate_aois_polygons()
+        aois_polygons, aois_gdf = self._generate_aois_polygons()
+
+        # Precompute unioned AOI geometry per AOI name (in pixel coordinates)
+        aoi_geometries = {
+            aoi_name: aois_gdf[aois_gdf['aoi'] == aoi_name]['geometry'].unary_union
+            for aoi_name in aois_gdf['aoi'].unique()
+        }
 
         final_aois_tiles_paths = {aoi: [] for aoi in aois_polygons.keys()}
         final_aois_polygons = {aoi: [] for aoi in aois_polygons.keys()}
         tiles_batch = []
 
         for aoi, polygons in aois_polygons.items():
+            aoi_geom = aoi_geometries.get(aoi)
             for _, polygon_row in tqdm(polygons.iterrows(),
                                        f"Generating polygon tiles for AOI {aoi}...",
                                        total=len(polygons)):
 
                 polygon = polygon_row['geometry']
                 polygon_id = polygon_row[self.unique_polygon_id_column_name]
+
+                if aoi_geom is not None and polygon.area > 0:
+                    intersection_ratio = polygon.intersection(aoi_geom).area / polygon.area
+                    if intersection_ratio < self.min_intersection_ratio:
+                        continue
 
                 polygon_tile, translated_polygon = self.raster.get_polygon_tile(
                     polygon=polygon,

--- a/geodataset/tilerize/raster_polygon_tilerizer.py
+++ b/geodataset/tilerize/raster_polygon_tilerizer.py
@@ -138,6 +138,9 @@ class RasterPolygonTilerizer:
     output_dtype : str
         The data type to use when saving the tile. If None, the original data type will
         be used. Currently supported values are None and 'uint8' (0-255).
+    compress : str, optional
+        Compression to apply when saving tiles. Supported values are None (no compression)
+        and 'zstd' (lossless). Defaults to None.
     """
 
     unique_polygon_id_column_name = 'polygon_id_geodataset'
@@ -165,7 +168,8 @@ class RasterPolygonTilerizer:
                  coco_categories_list: list[dict] = None,
                  tile_batch_size: int = 1000,
                  temp_dir: str or Path = './tmp',
-                 output_dtype: str = None):
+                 output_dtype: str = None,
+                 compress: str = None):
 
         self.raster_path = str(raster_path)
         self.labels_path = Path(labels_path) if labels_path is not None else None
@@ -185,6 +189,7 @@ class RasterPolygonTilerizer:
         self.tile_batch_size = tile_batch_size
         self.temp_dir = Path(temp_dir)
         self.output_dtype = output_dtype
+        self.compress = compress
 
         self._check_parameters()
         self._check_aois_config()
@@ -394,7 +399,8 @@ class RasterPolygonTilerizer:
             tiles,
             output_folder=self.tiles_folder_path / aoi,
             apply_mask=False,  # We don't apply mask for polygon tiles and let user handle it if needed when loading it for training/inference
-            output_dtype=self.output_dtype
+            output_dtype=self.output_dtype,
+            compress=self.compress
         )
         return tiles_paths
 

--- a/geodataset/tilerize/raster_polygon_tilerizer.py
+++ b/geodataset/tilerize/raster_polygon_tilerizer.py
@@ -351,14 +351,15 @@ class RasterPolygonTilerizer:
                     if polygon.area == 0:
                         return 1.0
                     try:
-                        return polygon.intersection(aoi_geom).area / polygon.area
+                        ratio = polygon.intersection(aoi_geom).area / polygon.area
                     except Exception:
                         p = polygon.buffer(0) if not polygon.is_valid else polygon
                         a = aoi_geom.buffer(0) if not aoi_geom.is_valid else aoi_geom
-                        return p.intersection(a).area / p.area
+                        ratio = p.intersection(a).area / p.area
+                    return ratio
 
                 ratios = polygons['geometry'].apply(_intersection_ratio)
-                mask = ratios >= self.min_intersection_ratio
+                mask = ratios >= self.min_intersection_ratio - 1e-9
                 skipped_count = (~mask).sum()
                 if skipped_count > 0:
                     print(f"AOI '{aoi}': skipping {skipped_count}/{len(polygons)} polygons due to insufficient AOI intersection (min_intersection_ratio={self.min_intersection_ratio}).")

--- a/geodataset/tilerize/raster_polygon_tilerizer.py
+++ b/geodataset/tilerize/raster_polygon_tilerizer.py
@@ -28,9 +28,10 @@ class RasterPolygonTilerizer:
         Path to the labels. Supported formats are: .gpkg, .geojson, .shp, .xml, .csv.
     output_path : str or pathlib.Path
         Path to parent folder where to save the image tiles and associated labels.
-    tile_size : int
+    tile_size : int or None
         If use_variable_tile_size is set to True, then this parameter defines the maximum size of the tiles in pixels (tile_size, tile_size).
-        If use_variable_tile_size is set to False, all polygon tiles will have the same size (tile_size, tile_size).
+        Set to None to allow unlimited tile size (tile will be sized to fit the polygon + buffer with no cap).
+        If use_variable_tile_size is set to False, all polygon tiles will have the same size (tile_size, tile_size) and this must be an int.
     use_variable_tile_size: bool
         Whether to use variable tile size. If True, the tile size will match the size of the polygon,
          with a buffer defined by variable_tile_size_pixel_buffer.
@@ -142,7 +143,7 @@ class RasterPolygonTilerizer:
                  raster_path: str or Path,
                  labels_path: str or Path or None,
                  output_path: str or Path,
-                 tile_size: int,
+                 tile_size: Optional[int],
                  use_variable_tile_size: bool,
                  variable_tile_size_pixel_buffer: int or None,
                  labels_gdf: gpd.GeoDataFrame = None,
@@ -200,8 +201,12 @@ class RasterPolygonTilerizer:
     def _check_parameters(self):
         assert assert_raster_exists(self.raster_path), \
             f"Raster file not found at {self.raster_path}."
-        assert isinstance(self.tile_size, int) and self.tile_size > 0, \
-            "The tile size must be and integer greater than 0."
+        if self.use_variable_tile_size:
+            assert self.tile_size is None or (isinstance(self.tile_size, int) and self.tile_size > 0), \
+                "tile_size must be a positive integer or None when use_variable_tile_size is True."
+        else:
+            assert isinstance(self.tile_size, int) and self.tile_size > 0, \
+                "tile_size must be a positive integer when use_variable_tile_size is False."
         assert not (self.ground_resolution and self.scale_factor), \
             "Both a ground_resolution and a scale_factor were provided. Please only specify one."
         if self.use_variable_tile_size:

--- a/geodataset/tilerize/raster_polygon_tilerizer.py
+++ b/geodataset/tilerize/raster_polygon_tilerizer.py
@@ -347,7 +347,12 @@ class RasterPolygonTilerizer:
                 polygon_id = polygon_row[self.unique_polygon_id_column_name]
 
                 if aoi_geom is not None and polygon.area > 0:
-                    intersection_ratio = polygon.intersection(aoi_geom).area / polygon.area
+                    try:
+                        intersection_ratio = polygon.intersection(aoi_geom).area / polygon.area
+                    except Exception:
+                        p = polygon.buffer(0) if not polygon.is_valid else polygon
+                        a = aoi_geom.buffer(0) if not aoi_geom.is_valid else aoi_geom
+                        intersection_ratio = p.intersection(a).area / p.area
                     if intersection_ratio < self.min_intersection_ratio:
                         continue
 

--- a/geodataset/tilerize/raster_polygon_tilerizer.py
+++ b/geodataset/tilerize/raster_polygon_tilerizer.py
@@ -344,22 +344,32 @@ class RasterPolygonTilerizer:
 
         for aoi, polygons in aois_polygons.items():
             aoi_geom = aoi_geometries.get(aoi)
+
+            # Filtering polygons based on their intersection ratio with the AOI geometry, if AOI geometry is available
+            if aoi_geom is not None:
+                def _intersection_ratio(polygon):
+                    if polygon.area == 0:
+                        return 1.0
+                    try:
+                        return polygon.intersection(aoi_geom).area / polygon.area
+                    except Exception:
+                        p = polygon.buffer(0) if not polygon.is_valid else polygon
+                        a = aoi_geom.buffer(0) if not aoi_geom.is_valid else aoi_geom
+                        return p.intersection(a).area / p.area
+
+                ratios = polygons['geometry'].apply(_intersection_ratio)
+                mask = ratios >= self.min_intersection_ratio
+                skipped_count = (~mask).sum()
+                if skipped_count > 0:
+                    print(f"AOI '{aoi}': skipping {skipped_count}/{len(polygons)} polygons due to insufficient AOI intersection (min_intersection_ratio={self.min_intersection_ratio}).")
+                polygons = polygons[mask]
+
             for _, polygon_row in tqdm(polygons.iterrows(),
                                        f"Generating polygon tiles for AOI {aoi}...",
                                        total=len(polygons)):
 
                 polygon = polygon_row['geometry']
                 polygon_id = polygon_row[self.unique_polygon_id_column_name]
-
-                if aoi_geom is not None and polygon.area > 0:
-                    try:
-                        intersection_ratio = polygon.intersection(aoi_geom).area / polygon.area
-                    except Exception:
-                        p = polygon.buffer(0) if not polygon.is_valid else polygon
-                        a = aoi_geom.buffer(0) if not aoi_geom.is_valid else aoi_geom
-                        intersection_ratio = p.intersection(a).area / p.area
-                    if intersection_ratio < self.min_intersection_ratio:
-                        continue
 
                 polygon_tile, translated_polygon = self.raster.get_polygon_tile(
                     polygon=polygon,

--- a/geodataset/utils/categories/quebec_trees/quebec_trees_categories_subset_2.json
+++ b/geodataset/utils/categories/quebec_trees/quebec_trees_categories_subset_2.json
@@ -10,46 +10,6 @@
         },
         {
             "id": 2,
-            "name": "Pinopsida",
-            "global_id": 194,
-            "is_taxon": true,
-            "rank": "class",
-            "other_names": [
-                 "Conifere"
-            ],
-            "supercategory": 7707728
-        },
-        {
-            "id": 3,
-            "name": "Magnoliopsida",
-            "global_id": 220,
-            "is_taxon": true,
-            "rank": "class",
-            "other_names": [
-                "Feuillus",
-                "QURU", 
-                "OSVI", 
-                "PRPE",
-                "FRNI"
-            ],
-            "including_names": [
-                "Quercus rubra L.",
-                "Ostrya virginiana (Mill.) K.Koch",
-                "Prunus pensylvanica L.fil.", 
-                "Fraxinus nigra Marshall"
-                
-            ],
-            "including_global_ids": [
-                2880539,
-                5332289,
-                8202030,
-                3172369
-            ],
-            "supercategory": 7707728
-        },
-
-        {
-            "id": 4,
             "name": "Thuja occidentalis L.",
             "global_id": 2684178,
             "is_taxon": true,
@@ -61,7 +21,7 @@
             "supercategory": 2684168
         },
         {
-            "id": 5,
+            "id": 3,
             "name": "Abies balsamea (L.) Mill.",
             "global_id": 2685383,
             "is_taxon": true,
@@ -73,7 +33,7 @@
             "supercategory": 2684876
         },
         {
-            "id": 6,
+            "id": 4,
             "name": "Larix laricina (Du Roi) K.Koch",
             "global_id": 2686231,
             "is_taxon": true,
@@ -85,7 +45,7 @@
             "supercategory": 2686156
         },
         {
-            "id": 7,
+            "id": 5,
             "name": "Tsuga canadensis (L.)",
             "global_id": 2687182,
             "is_taxon": true,
@@ -97,20 +57,7 @@
             "supercategory": 8527396
         },
         {
-            "id": 8,
-            "name": "Betula L.",
-            "global_id": 2875008,
-            "is_taxon": true,
-            "rank": "genus",
-            "other_names": [
-                "Betula", "BEPO"
-            ],
-            "including_names":  ["Betula populifolia Marshall"],
-            "including_global_ids": [8184083],
-            "supercategory": 4688
-        },
-        {
-            "id": 9,
+            "id": 6,
             "name": "Fagus grandifolia Ehrh.",
             "global_id": 2882274,
             "is_taxon": true,
@@ -122,7 +69,7 @@
             "supercategory": 2874875
         },
         {
-            "id": 10,
+            "id": 7,
             "name": "Populus L.",
             "global_id": 3040183,
             "is_taxon": true,
@@ -146,20 +93,8 @@
                 3040215
             ]
         },
-      
         {
-            "id": 11,
-            "name": "Acer L.",
-            "global_id": 3189834,
-            "is_taxon": true,
-            "rank": "genus",
-            "other_names": [
-                "Acer"
-            ],
-            "supercategory": 6657
-        },
-        {
-            "id": 12,
+            "id": 8,
             "name": "Acer pensylvanicum L.",
             "global_id": 3189836,
             "is_taxon": true,
@@ -171,7 +106,7 @@
             "supercategory": 3189834
         },
         {
-            "id": 13,
+            "id": 9,
             "name": "Acer saccharum Marshall",
             "global_id": 3189859,
             "is_taxon": true,
@@ -183,7 +118,7 @@
             "supercategory": 3189834
         },
         {
-            "id": 14,
+            "id": 10,
             "name": "Acer rubrum L.",
             "global_id": 3189883,
             "is_taxon": true,
@@ -195,7 +130,7 @@
             "supercategory": 3189834
         },
         {
-            "id": 15,
+            "id": 11,
             "name": "Pinus strobus L.",
             "global_id": 5284982,
             "is_taxon": true,
@@ -207,7 +142,7 @@
             "supercategory": 2684241
         },
         {
-            "id": 16,
+            "id": 12,
             "name": "Betula alleghaniensis Britton",
             "global_id": 5331779,
             "is_taxon": true,
@@ -219,7 +154,7 @@
             "supercategory": 2875008
         },
         {
-            "id": 17,
+            "id": 13,
             "name": "Betula papyrifera Marshall",
             "global_id": 5332120,
             "is_taxon": true,
@@ -231,7 +166,7 @@
             "supercategory": 2875008
         },
         {
-            "id": 18,
+            "id": 14,
             "name": "Picea A.Dietr.",
             "global_id": 7606064,
             "is_taxon": true,

--- a/geodataset/utils/utils.py
+++ b/geodataset/utils/utils.py
@@ -420,57 +420,96 @@ def coco_rle_segmentation_to_polygon(
     return mask_to_polygon(mask, simplify_tolerance, min_contour_points)
 
 
-def decode_coco_segmentation(coco_annotation: dict, output_type: str):
+def _coco_bbox(coco_annotation: dict, segmentation, coords_to_bbox):
+    """Bbox from the annotation's explicit 'bbox' field if present, else derived from segmentation."""
+    if 'bbox' in coco_annotation:
+        bbox_coco = coco_annotation['bbox']
+        return box(*[bbox_coco[0], bbox_coco[1], bbox_coco[0] + bbox_coco[2], bbox_coco[1] + bbox_coco[3]])
+    return coords_to_bbox(segmentation)
+
+
+def decode_coco_rle_segmentation(coco_annotation: dict, output_type: str):
     """
-    Decodes a COCO annotation segmentation into a shapely Polygon or MultiPolygon.
+    Decode an RLE-format COCO annotation segmentation. RLE is self-describing (it embeds its
+    raster size), so no image dimensions are needed.
 
     Parameters
     ----------
     coco_annotation: dict
-        The segmentation to decode.
+        The COCO annotation (its 'segmentation' must be RLE).
     output_type: str
-        The desired output type. Can be 'polygon', 'bbox' or 'mask'.
-
-    Returns
-    -------
-    Polygon or MultiPolygon or box or np.ndarray
-        The decoded segmentation.
+        'polygon', 'bbox' or 'mask'.
     """
     segmentation = coco_annotation['segmentation']
+    if output_type == 'polygon':
+        return coco_rle_segmentation_to_polygon(segmentation)
+    elif output_type == 'bbox':
+        return _coco_bbox(coco_annotation, segmentation, coco_rle_segmentation_to_bbox)
+    elif output_type == 'mask':
+        return coco_rle_segmentation_to_mask(segmentation)
+    else:
+        raise ValueError(f"Output type '{output_type}' not supported. Must be 'polygon', 'bbox' or 'mask'.")
 
+
+def decode_coco_coordinates_segmentation(coco_annotation: dict, output_type: str,
+                                         image_height: int = None, image_width: int = None):
+    """
+    Decode a polygon-coordinates COCO annotation segmentation.
+
+    ``image_height``/``image_width`` are only needed for ``output_type='mask'`` (to rasterize the
+    polygon). COCO stores size on the image, not the annotation, so the caller must supply it.
+
+    Parameters
+    ----------
+    coco_annotation: dict
+        The COCO annotation (its 'segmentation' must be polygon coordinates).
+    output_type: str
+        'polygon', 'bbox' or 'mask'.
+    image_height, image_width: int
+        Raster size of the tile the polygon lives in. Required for 'mask'.
+    """
+    segmentation = coco_annotation['segmentation']
+    if output_type == 'polygon':
+        return coco_coordinates_segmentation_to_polygon(segmentation)
+    elif output_type == 'bbox':
+        return _coco_bbox(coco_annotation, segmentation, coco_coordinates_segmentation_to_bbox)
+    elif output_type == 'mask':
+        if image_height is None or image_width is None:
+            raise ValueError(
+                "Rasterizing a polygon-coordinates segmentation to a mask requires image_height "
+                "and image_width (COCO stores size on the image, not the annotation)."
+            )
+        polygon = coco_coordinates_segmentation_to_polygon(segmentation)
+        return polygon_to_mask(polygon, image_height, image_width)
+    else:
+        raise ValueError(f"Output type '{output_type}' not supported. Must be 'polygon', 'bbox' or 'mask'.")
+
+
+def decode_coco_segmentation(coco_annotation: dict, output_type: str,
+                             image_height: int, image_width: int):
+    """
+    Decode a COCO annotation segmentation into a shapely Polygon/MultiPolygon, box, or mask,
+    dispatching on RLE vs polygon-coordinates format.
+
+    ``image_height``/``image_width`` are required and used when rasterizing a polygon-coordinates
+    segmentation to a mask (COCO stores size on the image, not the annotation). They are ignored
+    for RLE annotations and for 'polygon'/'bbox' outputs; if you only ever decode RLE and have no
+    image size, call ``decode_coco_rle_segmentation`` directly.
+
+    Parameters
+    ----------
+    coco_annotation: dict
+        The COCO annotation to decode.
+    output_type: str
+        'polygon', 'bbox' or 'mask'.
+    image_height, image_width: int
+        Raster size of the tile the annotation lives in.
+    """
+    segmentation = coco_annotation['segmentation']
     if ('is_rle_format' in coco_annotation and coco_annotation['is_rle_format']) or isinstance(segmentation, dict):
-        # Compressed RLE format
-        if output_type == 'polygon':
-            return coco_rle_segmentation_to_polygon(segmentation)
-        elif output_type == 'bbox':
-            if 'bbox' in coco_annotation:
-                # Directly use the provided bbox
-                bbox_coco = coco_annotation['bbox']
-                bbox = box(*[bbox_coco[0], bbox_coco[1], bbox_coco[0] + bbox_coco[2], bbox_coco[1] + bbox_coco[3]])
-            else:
-                bbox = coco_rle_segmentation_to_bbox(segmentation)
-            return bbox
-        elif output_type == 'mask':
-            return coco_rle_segmentation_to_mask(segmentation)
-        else:
-            raise ValueError(f"Output type '{output_type}' not supported. Must be 'polygon', 'bbox' or 'mask'.")
+        return decode_coco_rle_segmentation(coco_annotation, output_type)
     elif ('is_rle_format' in coco_annotation and not coco_annotation['is_rle_format']) or isinstance(segmentation, list):
-        # Coordinates format
-        if output_type == 'polygon':
-            return coco_coordinates_segmentation_to_polygon(segmentation)
-        elif output_type == 'bbox':
-            if 'bbox' in coco_annotation:
-                # Directly use the provided bbox
-                bbox_coco = coco_annotation['bbox']
-                bbox = box(*[bbox_coco[0], bbox_coco[1], bbox_coco[0] + bbox_coco[2], bbox_coco[1] + bbox_coco[3]])
-            else:
-                bbox = coco_coordinates_segmentation_to_bbox(segmentation)
-            return bbox
-        elif output_type == 'mask':
-            polygon = coco_coordinates_segmentation_to_polygon(segmentation)
-            return polygon_to_mask(polygon, coco_annotation['height'], coco_annotation['width'])
-        else:
-            raise ValueError(f"Output type '{output_type}' not supported. Must be 'polygon', 'bbox' or 'mask'.")
+        return decode_coco_coordinates_segmentation(coco_annotation, output_type, image_height, image_width)
     else:
         raise NotImplementedError("Could not find the segmentation type (RLE vs polygon coordinates).")
 
@@ -1645,7 +1684,7 @@ def coco_to_geopackage(coco_json_path: str,
 
         polygons = []
         for annotation in tile_annotations:
-            polygon = decode_coco_segmentation(annotation, 'polygon')
+            polygon = decode_coco_segmentation(annotation, 'polygon', tile_data['height'], tile_data['width'])
             polygons.append(polygon)
 
         gdf = gpd.GeoDataFrame({


### PR DESCRIPTION
## Summary

- **COCO mask decoding fix** — `decode_coco_segmentation` read `height`/`width` off the annotation, but COCO stores size on the image, so decoding polygon-coordinate masks raised `KeyError: 'height'` (only self-describing RLE worked). Split into `decode_coco_rle_segmentation` (no dims), `decode_coco_coordinates_segmentation` (dims for mask), and a `decode_coco_segmentation` dispatcher with **mandatory** `image_height`/`image_width`; all in-repo callers (raster datasets, aggregator, coco→gdf util) updated to pass dimensions from the tile/image. ⚠️ API break: `decode_coco_segmentation` now requires `image_height`/`image_width`.
- **RasterPolygonTilerizer improvements** — unlimited tile size, new `min_tile_size` and `min_intersection_ratio` parameters, `apply_aoi_mask` support, zstd compression; plus topology-exception and floating-point-precision fixes.
- **Categories** — added Quebec tree categories following Melisande's BalSAM paper.
